### PR TITLE
ldr:IPRRight -> ldr:IPRight

### DIFF
--- a/bp/license/rdflicense/allrightsreserved.ttl
+++ b/bp/license/rdflicense/allrightsreserved.ttl
@@ -20,5 +20,5 @@
         rdfs:label        "All rights reserved"@en ;
         cc:legalcode      <http://en.wikipedia.org/wiki/All_rights_reserved> ;
         dct:publisher     "None" ;
-        odrl:prohibition  [ odrl:action  ldr:IPRRight , ldr:DatabaseRight ] .
+        odrl:prohibition  [ odrl:action  ldr:IPRight , ldr:DatabaseRight ] .
 

--- a/bp/license/rdflicense/publicdomain.ttl
+++ b/bp/license/rdflicense/publicdomain.ttl
@@ -21,5 +21,5 @@
         cc:legalcode     "This statement can be applied to material truly in the public domain (because rights have expired, forfeited or are innaplicable). This text cannot be deemed as a license -namely, public domain works do not need to be licensed."@en ;
         dct:publisher    " None" ;
         dct:source       <http://en.wikipedia.org/wiki/Public_domain> ;
-        odrl:permission  [ odrl:action  ldr:IPRRight , ldr:DatabaseRight ] .
+        odrl:permission  [ odrl:action  ldr:IPRight , ldr:DatabaseRight ] .
 


### PR DESCRIPTION
`IPRRight` (double R) is not an LDR term, but `IPRight` is.