### PR TITLE
feat: add Evaluation Request Class definition to the Formal Semantics Document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.Rproj
+*.Rproj.user
+*.py[co]
+*.sw[nop]
+*~
+.DS_Store
+.vscode
+.idea/*

--- a/formal-semantics/config.js
+++ b/formal-semantics/config.js
@@ -38,6 +38,13 @@ var respecConfig = {
                 companyURL: "https://www.deonticdata.com/",
                 mailto: ""
             },
+            {
+                name: "Yassir Sellami",
+                url: "https://www.linkedin.com/in/yassir-sellami/",
+                company: "Gaia-X",
+                companyURL: "https://gaia-x.eu/",
+                mailto: "yassir.sellami@gaia-x.eu"
+            },
         ],
     group: "odrl",
     wgPublicList: "public-odrl",

--- a/formal-semantics/index.html
+++ b/formal-semantics/index.html
@@ -122,7 +122,50 @@ The default value is closed. -->
                 </ul></li>
         </ul>
 
-    </section>			
+            <h3>Formal Description of the Evaluation Request</h3>
+            <p>
+                As mentioned in the final paragraph of the introduction, an evaluator requires an <code>Evaluation Request</code> as input.
+                The evaluator uses the Evaluation Request to determine whether a particular action by an assignee on a target is permitted according to an ODRL policy.
+                The <code>Evaluation Request</code>, which is represented in RDF, is formally defined by the class <code>odrl-fs:EvaluationRequest</code> and MUST contain the following properties:
+            </p>
+            <ul>
+                <li><code>odrl:action</code>: The operation the assignee wants to perform/performed (e.g., use, read, modify).</li>
+                <li><code>odrl:assignee</code>: The party (e.g., person or organization) requesting/requested the action.</li>
+                <li><code>odrl:target</code>: The asset (e.g., file, document, data) on which the action is to be/was performed.</li>
+            </ul>
+            <p>
+                Optionally, the <code>odrl:assignee</code> node may include an <code>odrl:assigneeOf</code> property to indicate a targeted policy.
+                To ensure consistency, it is recommended that requests conform to the defined SHACL shapes.
+            </p>
+            <p>
+                For formal validation and integration, the <code>odrl-fs:EvaluationRequest</code> class is defined in an OWL ontology, with corresponding
+                SHACL shapes specifying structural constraints and a JSON-LD context to ensure semantic consistency across RDF representations.
+                These resources can be found at the following locations:
+                <ul>
+                    <li><a href="https://w3c.github.io/odrl/formal-semantics/ontology/owl.ttl" target="_blank">OWL Ontology</a></li>
+                    <li><a href="https://w3c.github.io/odrl/formal-semantics/ontology/shacl.ttl" target="_blank">SHACL Shapes</a></li>
+                    <li><a href="https://w3c.github.io/odrl/formal-semantics/ontology/json-ld_context.json" target="_blank">JSON-LD Context</a></li>
+                </ul>
+            </p>
+
+            <b>Evaluation Request Example:</b>
+            <pre>
+                {
+                  "@context": {
+                    "http://www.w3.org/ns/odrl.jsonld",
+                    "odrl-fs": "https://w3id.org/odrl-fs#"
+                  },
+                  "@type": "odrl-fs:EvaluationRequest",
+                  "action": "odrl:use",
+                  "assignee": {
+                    "@id": "http://example.org/party/Alice",
+                    "assigneeOf": "http://example.com/policy/13"
+                  },
+                  "target": "http://example.com/document/1234"
+                }
+            </pre>
+
+        </section>
 
     <section id="sectionPolicies">	
         <h2>Semantics of a Policy</h2>	

--- a/formal-semantics/ontology/json-ld_context.json
+++ b/formal-semantics/ontology/json-ld_context.json
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "odrl-fs": "https://w3id.org/odrl-fs#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "id": "@id",
+    "type": "@type",
+    "description": "https://schema.org/description",
+    "EvaluationRequest": "odrl-fs:EvaluationRequest",
+    "action": {
+      "@id": "odrl:action",
+      "@type": "http://www.w3.org/ns/odrl/2/Action"
+    },
+    "assignee": {
+      "@id": "odrl:assignee",
+      "@type": "http://www.w3.org/ns/odrl/2/Party"
+    },
+    "assigneeOf": {
+      "@id": "odrl:assigneeOf",
+      "@type": "http://www.w3.org/ns/odrl/2/Policy"
+    },
+    "target": {
+      "@id": "odrl:target",
+      "@type": "http://www.w3.org/ns/odrl/2/Asset"
+    }
+  }
+}

--- a/formal-semantics/ontology/owl.ttl
+++ b/formal-semantics/ontology/owl.ttl
@@ -1,0 +1,30 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix odrl-fs: <https://w3id.org/odrl-fs#> .
+
+odrl-fs:EvaluationRequest a rdfs:Class , owl:Class, skos:Concept ;
+    rdfs:isDefinedBy odrl-fs: ;
+    rdfs:label "Evaluation Request"@en ;
+    skos:definition "The evaluator uses the Evaluation Request to determine whether a particular action by an assignee on a target is permitted according to an ODRL policy."@en ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty odrl:action ;
+        owl:someValuesFrom odrl:Action
+    ] ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty odrl:assignee ;
+        owl:someValuesFrom odrl:Party
+    ] ;
+    rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty odrl:target ;
+        owl:someValuesFrom odrl:Asset
+    ] .
+
+odrl:assigneeOf a owl:ObjectProperty ;
+    rdfs:domain odrl:Party ;
+    rdfs:range odrl:Policy .

--- a/formal-semantics/ontology/shacl.ttl
+++ b/formal-semantics/ontology/shacl.ttl
@@ -1,0 +1,36 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix odrl-fs: <https://w3id.org/odrl-fs#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+odrl-fs:EvaluationRequestShape a sh:NodeShape ;
+    sh:targetClass odrl-fs:EvaluationRequest ;
+    
+    sh:property [
+        sh:path odrl:action ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class odrl:Action ;
+    ] ;
+    
+    sh:property [
+        sh:path odrl:assignee ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class odrl:Party ;
+    ] ;
+
+    sh:property [
+        sh:path odrl:target ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class odrl:Asset ;
+    ] .
+
+odrl-fs:AssigneeShape a sh:NodeShape ;
+    sh:targetObjectsOf odrl:assignee ;
+    sh:property [
+        sh:path odrl:assigneeOf ;
+        sh:maxCount 1 ;
+        sh:class odrl:Policy ;
+    ] .


### PR DESCRIPTION
- Add Evaluation Request definition
- Add an Evaluation Request example
- Add Evaluation Request ontology definition in:
  - OWL
  - SHACL
  - JSON-LD